### PR TITLE
Remove requirement that a watcher is only registered to one store 

### DIFF
--- a/src/__tests__/watcher.spec.ts
+++ b/src/__tests__/watcher.spec.ts
@@ -115,16 +115,26 @@ describe('createWatcher', () => {
         expect(changeHandler).toHaveBeenCalledTimes(1);
     });
 
-    it('Can only be subscribed to the store once', () => {
-        const { store, counterSelector } = setUp();
+    it('Can be subscribed to multiple stores', () => {
+        const { store, counterSelector, increment } = setUp();
+        const { store: store2, increment: increment2 } = setUp();
 
         const changeHandler = jest.fn();
 
         const watcher = createWatcher(counterSelector, changeHandler);
 
         watcher(store);
+        watcher(store2);
 
-        expect(() => watcher(store)).toThrowError();
+        store.dispatch(increment());
+
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+        expect(changeHandler.mock.calls[0][2].store).toBe(store);
+
+        store2.dispatch(increment2());
+
+        expect(changeHandler).toHaveBeenCalledTimes(2);
+        expect(changeHandler.mock.calls[1][2].store).toBe(store2);
     });
 
     it('Can be subscribed again after it has been unsubscribed', () => {

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -24,7 +24,7 @@ function watch<R>(
 /**
  * Extra data for a change listener
  */
-interface ChangeListenerExtra<S extends Store> {
+interface ChangeListenerExtra<S extends Store, D extends Dispatch = Dispatch> {
     /**
      * The store on which the change listerner was triggered
      */
@@ -32,7 +32,7 @@ interface ChangeListenerExtra<S extends Store> {
     /**
      * Dispatch method of the store
      */
-    dispatch: Dispatch;
+    dispatch: D;
 }
 
 /**
@@ -42,10 +42,10 @@ interface ChangeListenerExtra<S extends Store> {
  * @param oldValue The previous value that was in the store
  * @param extra Additional data for the change listener
  */
-type ChangeListener<T, S extends Store> = (
+type ChangeListener<T, S extends Store, D extends Dispatch = Dispatch> = (
     newValue: T,
     oldValue: T,
-    extra: ChangeListenerExtra<S>
+    extra: ChangeListenerExtra<S, D>
 ) => void;
 
 /**
@@ -64,9 +64,14 @@ type StoreWatcher<S extends Store> = (store: S) => Unsubscribe;
  *
  * @returns An unbound watcher for the state returned by selector
  */
-export function createWatcher<State, R, S extends Store<State> = Store<State>>(
+export function createWatcher<
+    State,
+    R,
+    S extends Store<State> = Store<State>,
+    D extends Dispatch = Dispatch
+>(
     selector: Selector<State, R>,
-    listener: ChangeListener<R, S>
+    listener: ChangeListener<R, S, D>
 ): StoreWatcher<S> {
     let caller = '<unknown>';
     if (log.enabled) {
@@ -75,9 +80,9 @@ export function createWatcher<State, R, S extends Store<State> = Store<State>>(
     }
     return store => {
         const watcher = watch(() => selector(store.getState()));
-        const opts: ChangeListenerExtra<S> = {
+        const opts: ChangeListenerExtra<S, D> = {
             store: store,
-            dispatch: store.dispatch.bind(store),
+            dispatch: store.dispatch.bind(store) as D,
         };
         return store.subscribe(
             watcher((newValue, oldValue) => {


### PR DESCRIPTION
A watcher can perfectly handle being registered to multiple stores at
once without it affecting the values it triggers a callback on.

Since state is only accessed from within the `(store) => {}` function,
which is always called when a watcher is subscribed to a store, it can
handle multiple stores at once.

